### PR TITLE
Add documentation on how to use a custom config.yaml in Docker containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ docker run \
   place1/wg-access-server
 ```
 
+To use a custom [configuration](#configuration) file, please add a `CONFIG` environment variable and make sure the configuration file is mounted:
+```
+  ...
+  -e CONFIG=/config/config.yaml
+  -v ./config.yaml:/config/config.yaml
+  ...
+```
+
 ## Configuration
 
 You can configure the server using a config file.


### PR DESCRIPTION
Since not all settings can be configured with environment variables, it might be necessary to use a custom config.yaml. Documentation how to add this in to Docker containers is missing, so therefore I created this PR.