### PR TITLE
Use email property as foldername

### DIFF
--- a/internal/auth/dex.go
+++ b/internal/auth/dex.go
@@ -127,7 +127,16 @@ func (d *DexIntegration) handleCallback(session *scs.SessionManager) http.Handle
 			panic(err)
 		}
 
-		session.Put(r.Context(), "auth/subject", idToken.Subject)
+		// Extract custom claims
+		var claims struct {
+			Email    string `json:"email"`
+		}
+		if err := idToken.Claims(&claims); err != nil {
+			panic(err)
+		}
+
+		logrus.Infof("Authenticated as %s", claims.Email)
+		session.Put(r.Context(), "auth/email", claims.Email)
 		http.Redirect(w, r, "/", http.StatusSeeOther)
 	}
 }

--- a/internal/auth/dex.go
+++ b/internal/auth/dex.go
@@ -100,7 +100,7 @@ func (d *DexIntegration) handleLogin(w http.ResponseWriter, r *http.Request) {
 
 func (d *DexIntegration) handleCallback(session *scs.SessionManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		logrus.Info("handling callback")
+		logrus.Info("handling callback for url: %s", r.URL)
 		state := r.URL.Query().Get("state")
 
 		// Verify state.

--- a/internal/web/add_device.go
+++ b/internal/web/add_device.go
@@ -31,7 +31,7 @@ func AddDevice(session *scs.SessionManager, devices *services.DeviceManager) htt
 			return
 		}
 
-		user := session.GetString(r.Context(), "auth/subject")
+		user := session.GetString(r.Context(), "auth/email")
 
 		device, err := devices.AddDevice(user, req.Name, req.PublicKey)
 		if err != nil {

--- a/internal/web/delete_device.go
+++ b/internal/web/delete_device.go
@@ -21,7 +21,7 @@ func DeleteDevice(session *scs.SessionManager, devices *services.DeviceManager) 
 			return
 		}
 
-		user := session.GetString(r.Context(), "auth/subject")
+		user := session.GetString(r.Context(), "auth/email")
 
 		if err := devices.DeleteDevice(user, name); err != nil {
 			logrus.Error(errors.Wrap(err, "failed to remove device"))

--- a/internal/web/list_devices.go
+++ b/internal/web/list_devices.go
@@ -20,7 +20,7 @@ type ListDeviceResponse struct {
 
 func ListDevices(session *scs.SessionManager, devices *services.DeviceManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		user := session.GetString(r.Context(), "auth/subject")
+		user := session.GetString(r.Context(), "auth/email")
 
 		devices, err := devices.ListDevices(user)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -90,7 +90,7 @@ func main() {
 	secureRouter := router.PathPrefix("/").Subrouter()
 	secureRouter.Use(func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if config.IsAuthEnabled(conf) && session.GetString(r.Context(), "auth/subject") == "" {
+			if config.IsAuthEnabled(conf) && session.GetString(r.Context(), "auth/email") == "" {
 				http.Redirect(w, r, "/auth/login", http.StatusTemporaryRedirect)
 			} else {
 				next.ServeHTTP(w, r)


### PR DESCRIPTION
The OpenID Token was used as folder name. However, this token is changing all the time, so a user can't find his previously created profiles. It makes more sense to use the email address instead.

Fixes #3 