### PR TITLE
Docs and helm fix

### DIFF
--- a/deploy/helm/wg-access-server/README.md
+++ b/deploy/helm/wg-access-server/README.md
@@ -26,7 +26,7 @@ The command removes all the Kubernetes components associated with the chart and 
 ```yaml
 config:
   wireguard:
-    externalHost: "<loadbalancer-ip>:51820"
+    externalHost: "<loadbalancer-ip>"
 wireguard:
   config:
     privateKey: "<wireguard-private-key>"

--- a/deploy/helm/wg-access-server/templates/configmap.yaml
+++ b/deploy/helm/wg-access-server/templates/configmap.yaml
@@ -6,6 +6,6 @@ metadata:
     {{- include "wg-access-server.labels" . | nindent 4 }}
 data:
   config.yaml: |-
-{{- if .Values.config.wireguard }}
-{{ toYaml .Values.config.wireguard | indent 4 }}
+{{- if .Values.config }}
+{{ toYaml .Values.config | indent 4 }}
 {{- end }}

--- a/deploy/helm/wg-access-server/templates/deployment.yaml
+++ b/deploy/helm/wg-access-server/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
       {{- include "wg-access-server.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
       labels:
         {{- include "wg-access-server.selectorLabels" . | nindent 8 }}
     spec:

--- a/deploy/helm/wg-access-server/templates/ingress.yaml
+++ b/deploy/helm/wg-access-server/templates/ingress.yaml
@@ -29,6 +29,6 @@ spec:
           - path: /
             backend:
               serviceName: {{ $fullName }}-web
-              servicePort: 80
+              servicePort: 8000
   {{- end }}
 {{- end }}

--- a/deploy/helm/wg-access-server/templates/ingress.yaml
+++ b/deploy/helm/wg-access-server/templates/ingress.yaml
@@ -29,6 +29,6 @@ spec:
           - path: /
             backend:
               serviceName: {{ $fullName }}-web
-              servicePort: 8000
+              servicePort: 80
   {{- end }}
 {{- end }}

--- a/deploy/helm/wg-access-server/templates/service.yaml
+++ b/deploy/helm/wg-access-server/templates/service.yaml
@@ -23,7 +23,14 @@ metadata:
   name: {{ $fullName }}-wireguard
   labels:
     {{- include "wg-access-server.labels" . | nindent 4 }}
+{{- if .Values.wireguard.service.annotations }}
+  annotations:
+{{ toYaml .Values.wireguard.service.annotations | indent 4 }}
+{{- end }}
 spec:
+{{- if .Values.wireguard.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.wireguard.service.externalTrafficPolicy }}
+{{- end }}
   type: {{ .Values.wireguard.service.type }}
 {{- if .Values.wireguard.service.loadBalancerIP }}
   loadBalancerIP: {{ .Values.wireguard.service.loadBalancerIP }}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -140,12 +140,12 @@ auth:
     # You can create a user using "htpasswd -nB <username>"
     users: []
   oidc:
-    name: ""
-    issuer: ""
+    name: "" # anything you want
+    issuer: "" # Should point to the oidc url without .well-known
     clientID: ""
     clientSecret: ""
-    scopes: ""
-    redirectURL: ""
+    scopes: null  # list of scopes, defaults to ["openid"]
+    redirectURL: "" # full url you want the oidc to redirect to, example: https://vpn-admin.example.com/finish-signin
     # Optionally restrict login to users with an allowed email domain
     # if empty or omitted, any email domain will be allowed.
     emailDomains:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,8 +59,7 @@ wireguard:
   # If this value is empty then the server will use an in-memory
   # generated key
   privateKey: ""
-  # ExternalAddress is the address that clients
-  # use to connect to the wireguard interface
+  # ExternalAddress is the address (without port) that clients use to connect to the wireguard interface
   # By default, this will be empty and the web ui
   # will use the current page's origin i.e. window.location.origin
   # Optional


### PR DESCRIPTION
A couple of super minor things.

Docs:
* I got bit by `scope: ""` in the docs for oidc,  and had to dig in code/error messages to realize issuer was the url, and redirect url could be anything

Helm charts:
* Service - I use external-dns annotations to let my loadbalancer ips define a hostname, so added support for annotations
* Service - Added support for service externalTrafficPolicy - `service.spec.externalTrafficPolicy - denotes if this Service desires to route external traffic to node-local or cluster-wide endpoints. There are two available options: Cluster (default) and Local. Cluster obscures the client source IP and may cause a second hop to another node, but should have good overall load-spreading. Local preserves the client source IP and avoids a second hop for LoadBalancer and NodePort type services, but risks potentially imbalanced traffic spreading.`
* Ingress needs to point at the container port (8000) not the service port (80)
* Made the config map changes restart the deployment (checksum annotation suggested by helm)
* Made the configmap have the entire config section. I'm pretty sure i didn't break anything since only including wireguard is one level too deep and keys won't match up.