### PR TITLE
Enable setting different service type for web interface and using existing PVC for persistence.

### DIFF
--- a/deploy/helm/wg-access-server/Chart.yaml
+++ b/deploy/helm/wg-access-server/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 appVersion: 0.2.2
 description: A Wireguard VPN Access Server
 name: wg-access-server
-version: 0.2.2
+version: 0.2.2.1

--- a/deploy/helm/wg-access-server/README.md
+++ b/deploy/helm/wg-access-server/README.md
@@ -27,13 +27,22 @@ The command removes all the Kubernetes components associated with the chart and 
 config:
   wireguard:
     externalHost: "<loadbalancer-ip>"
+
+web:
+  service:
+    type: "LoadBalancer"
+    loadBalancerIP: "<loadbalancer-ip>"
+
 wireguard:
   config:
     privateKey: "<wireguard-private-key>"
   service:
     type: "LoadBalancer"
+    loadBalancerIP: "<loadbalancer-ip>"
+
 persistence:
   enabled: true
+
 ingress:
   enabled: true
   hosts: ["vpn.example.com"]
@@ -47,6 +56,7 @@ ingress:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | config | object | `{}` | inline wg-access-server config (config.yaml) |
+| web.service.type | string | `"ClusterIP"` |  |
 | wireguard.config.privateKey | string | "" | A wireguard private key. You can generate one using `$ wg genkey` |
 | wireguard.service.type | string | `"ClusterIP"` |  |
 | ingress.enabled | bool | `false` |  |
@@ -54,6 +64,7 @@ ingress:
 | ingress.tls | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | persistence.enabled | bool | `false` |  |
+| persistence.existingClaim | string | `""` | Use existing PVC claim for persistence instead |
 | persistence.size | string | `"100Mi"` |  |
 | persistence.subPath | string | `""` |  |
 | persistence.annotations | object | `{}` |  |

--- a/deploy/helm/wg-access-server/README.md
+++ b/deploy/helm/wg-access-server/README.md
@@ -28,10 +28,13 @@ config:
   wireguard:
     externalHost: "<loadbalancer-ip>"
 
-web:
-  service:
-    type: "LoadBalancer"
-    loadBalancerIP: "<loadbalancer-ip>"
+# wg access server is an http server without TLS. Exposing it via a loadbalancer is NOT secure!
+# Uncomment the following section only if you are running on private network or simple testing.
+# A much better option would be TLS terminating ingress controller or reverse-proxy.
+# web:
+#   service:
+#     type: "LoadBalancer"
+#     loadBalancerIP: "<loadbalancer-ip>"
 
 wireguard:
   config:
@@ -50,6 +53,8 @@ ingress:
     - hosts: ["vpn.example.com"]
       secretName: "tls-wg-access-server"
 ```
+
+
 
 ## All Configuration
 

--- a/deploy/helm/wg-access-server/templates/deployment.yaml
+++ b/deploy/helm/wg-access-server/templates/deployment.yaml
@@ -81,7 +81,7 @@ spec:
         - name: data
         {{- if .Values.persistence.enabled }}
           persistentVolumeClaim:
-            claimName: "{{ $fullName }}"
+            claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ $fullName }}{{- end }}
         {{- end }}
         {{- if not .Values.persistence.enabled }}
           emptyDir: {}

--- a/deploy/helm/wg-access-server/templates/service.yaml
+++ b/deploy/helm/wg-access-server/templates/service.yaml
@@ -5,8 +5,18 @@ metadata:
   name: {{ $fullName }}-web
   labels:
     {{- include "wg-access-server.labels" . | nindent 4 }}
+{{- if .Values.web.service.annotations }}
+  annotations:
+    {{ toYaml .Values.web.service.annotations | indent 4 }}
+{{- end }}
 spec:
-  type: ClusterIP
+{{- if .Values.web.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.web.service.externalTrafficPolicy }}
+{{- end }}
+  type: {{  .Values.web.service.type }}
+{{- if .Values.web.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.web.service.loadBalancerIP }}
+{{- end }}
   ports:
     - port: 80
       targetPort: 8000

--- a/deploy/helm/wg-access-server/values.yaml
+++ b/deploy/helm/wg-access-server/values.yaml
@@ -5,6 +5,8 @@ web:
   config:
     adminUsername: ""
     adminPassword: ""
+  service:
+    type: ClusterIP
 
 wireguard:
   config:


### PR DESCRIPTION
I am using wg-access-server with MetalLB-BGP. Currently, the web interface service type is only ClusterIP. This change enables setting the web service type `LoadBalancer`.

In addition, the change also enables using an existing claim for persistence instead of creating it on deployment time.