### PR TITLE
Github action supporting build multi-arch images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
         id: prep
         run: |
           TAG=null
-          IMAGE=timtor/wg-access-server
+          IMAGE=place1/wg-access-server
           REF="${{ github.ref }}"
 
           if [[ "$REF" == refs/heads/master ]]; then

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,57 @@
+name: Build and push docker images
+
+on:
+  push:
+    branches:
+      - "master"
+
+    tags:
+      - "*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prepare
+        id: prep
+        run: |
+          TAG=null
+          IMAGE=timtor/wg-access-server
+          REF="${{ github.ref }}"
+
+          if [[ "$REF" == refs/heads/master ]]; then
+            TAG="$IMAGE:edge"
+
+          elif [[ "$REF" == refs/tags/* ]]; then
+            VERSION="${REF$refs/tags/}"
+            TAG="$IMAGE:$VERSION,$IMAGE:latest"
+          fi
+
+          echo ::set-output name=tag::${TAG}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: latest
+          driver-opts: image=moby/buildkit:master
+
+      - name: Login Docker hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          platforms: linux/amd64, linux/arm64, linux/arm/v7
+          push: true
+          tags: ${{ steps.prep.outputs.tag }}


### PR DESCRIPTION
This PR is for github action supporting auto build multi-arch images (issue #65).

The build will be triggered while
1. you push a commit on master branch
2. you push a tag on a commit

As the result, there will be three kind of image tag, the semver tag like `0.2.5`, the `latest` tag refering the newest semver, and the `edge` tag refering top most commit on master branch.

### Note that
Before merging, please add secrets `DOCKER_USERNAME` and `DOCKER_TOKEN` to the project secrets, enabling login into docker hub.