### PR TITLE
Fix OIDC claims granting admin by default

### DIFF
--- a/docs/4-auth.md
+++ b/docs/4-auth.md
@@ -62,7 +62,7 @@ auth:
     # This feature is used to define wg-access-server admins
     # based off a claim in your OIDC token
     # See https://github.com/Knetic/govaluate/blob/9aa49832a739dcd78a5542ff189fb82c3e423116/MANUAL.md for how to write rules
-    userClaimsRules:
+    claimMapping:
       admin: "'WireguardAdmins' in group_membership"
   gitlab:
     name: "My Gitlab Backend"

--- a/pkg/authnz/authconfig/oidc.go
+++ b/pkg/authnz/authconfig/oidc.go
@@ -117,9 +117,11 @@ func (c *OIDCConfig) callbackHandler(runtime *authruntime.ProviderRuntime, oauth
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			if val, ok := result.(bool); ok {
+			
+			// If result is 'false' or an empty string then don't include the Claim
+			if val, ok := result.(bool); ok && val {
 				claims.Add(claimName, strconv.FormatBool(val))
-			} else if val, ok := result.(string); ok {
+			} else if val, ok := result.(string); ok && len(val) > 0 {
 				claims.Add(claimName, val)
 			}
 		}


### PR DESCRIPTION
Currently OIDC check based claims will grant Admin status by default, because the rest of the code checks just for the existence of a Claim, not it's value.

So we update the OIDC claim verification logic to respect that by asserting the claim check's value is 'truthy' before adding it.

Fixes #84 