### PR TITLE
helm chart: configurable session affinity

### DIFF
--- a/deploy/helm/wg-access-server/templates/service.yaml
+++ b/deploy/helm/wg-access-server/templates/service.yaml
@@ -39,7 +39,7 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.wireguard.service.type }}
-  sessionAffinity: ClientIP
+  sessionAffinity: {{ .Values.wireguard.service.sessionAffinity }}
 {{- if .Values.wireguard.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ .Values.wireguard.service.externalTrafficPolicy }}
 {{- end }}

--- a/deploy/helm/wg-access-server/values.yaml
+++ b/deploy/helm/wg-access-server/values.yaml
@@ -12,6 +12,7 @@ wireguard:
   config:
     privateKey: ""
   service:
+    sessionAffinity: ClientIP
     type: ClusterIP
 
 persistence:


### PR DESCRIPTION
Wireguard service fails to configure load balancer on AWS EKS with
```
  Warning  SyncLoadBalancerFailed  70s (x7 over 6m25s)  service-controller  Error syncing load balancer: failed to ensure load balancer: unsupported load balancer affinity: ClientIP
```
this change makes sessionAffinity parameter configurable