### PR TITLE
Add optionnal initContainer to fix sysctl config

### DIFF
--- a/deploy/helm/wg-access-server/templates/deployment.yaml
+++ b/deploy/helm/wg-access-server/templates/deployment.yaml
@@ -27,6 +27,20 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.sysctlInitContainer }}
+      initContainers:
+      - command:
+        - sysctl
+        - -w
+        - net.ipv4.ip_forward=1
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        name: init-sysctl
+        securityContext:
+          privileged: true
+          runAsNonRoot: false
+          runAsUser: 0
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/deploy/helm/wg-access-server/values.yaml
+++ b/deploy/helm/wg-access-server/values.yaml
@@ -79,3 +79,12 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# sysctlInitContainer flag adds an initContainer named "init-sysctl" to wg-access-server deployment.
+# The goal is to set the sysctl net.ipv4.ip_forward=1 to allow packet routing through node.
+# This initContainer needs to run as privileged, but this is only limited to
+# the initContainer run time, the main container will remain unprivileged as expected.
+# Use case : 
+#   DNS is functionning properly through VPN but does not work for standard traffic. 
+# NB : If you have no problem with wireguard traffic, you should not enable this initContainer
+sysctlInitContainer: false


### PR DESCRIPTION
This request will add an optionnal flag to helm chart values.yaml, that let people add an initContainer to fix sysctl missing "net.ipv4.ip_forward=1" issue. (like https://github.com/Place1/wg-access-server/issues/140)

Here is an exrtract of the documentation I added to values/yaml : 

> sysctlInitContainer flag adds an initContainer named "init-sysctl" to wg-access-server deployment.
> The goal is to set the sysctl net.ipv4.ip_forward=1 to allow packet routing through node.
> This initContainer needs to run as privileged, but this is only limited to the initContainer run time, the main container will remain unprivileged as expected.
> Use case : 
>  DNS is functionning properly through VPN but does not work for standard traffic. 
> 
> *NB : If you have no problem with wireguard traffic, you should not enable this initContainer*