### PR TITLE
[helm] add option to specify an existingSecret or a specific nodePort

### DIFF
--- a/deploy/helm/wg-access-server/README.md
+++ b/deploy/helm/wg-access-server/README.md
@@ -64,6 +64,7 @@ ingress:
 | web.service.type | string | `"ClusterIP"` |  |
 | wireguard.config.privateKey | string | "" | A wireguard private key. You can generate one using `$ wg genkey` |
 | wireguard.service.type | string | `"ClusterIP"` |  |
+| wireguard.service.nodePort | int | `nil` | When `NodePort` is used as `service.type`, a static nodePort can be added |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts | string | `nil` |  |
 | ingress.tls | list | `[]` |  |

--- a/deploy/helm/wg-access-server/README.md
+++ b/deploy/helm/wg-access-server/README.md
@@ -84,3 +84,4 @@ ingress:
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"place1/wg-access-server"` |  |
 | imagePullSecrets | list | `[]` |  |
+| existingSecret | string | `""` | Allow the use of an existing secret for admin username, password and private key |

--- a/deploy/helm/wg-access-server/templates/deployment.yaml
+++ b/deploy/helm/wg-access-server/templates/deployment.yaml
@@ -41,28 +41,14 @@ spec:
             - name: wireguard
               containerPort: 51820
               protocol: UDP
-          env:
-            {{- if .Values.wireguard.config.privateKey }}
-            - name: WG_WIREGUARD_PRIVATE_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ $fullName }}"
-                  key: privateKey
-            {{- end }}
-            {{- if .Values.web.config.adminUsername }}
-            - name: WG_ADMIN_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ $fullName }}"
-                  key: adminUsername
-            {{- end}}
-            {{- if .Values.web.config.adminPassword }}
-            - name: WG_ADMIN_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: "{{ $fullName }}"
-                  key: adminPassword
-            {{- end}}
+          envFrom:
+          - secretRef:
+              {{- if .Values.existingSecret }}
+              name: {{ .Values.existingSecret }}
+              {{- else }}
+              name: {{ $fullName }}
+              {{- end }}
+          env: {}
           volumeMounts:
             - name: tun
               mountPath: /dev/net/tun

--- a/deploy/helm/wg-access-server/templates/deployment.yaml
+++ b/deploy/helm/wg-access-server/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           securityContext:
             capabilities:
               add: ['NET_ADMIN']
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/deploy/helm/wg-access-server/templates/deployment.yaml
+++ b/deploy/helm/wg-access-server/templates/deployment.yaml
@@ -27,6 +27,20 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.sysctlInitContainer }}
+      initContainers:
+      - command:
+        - sysctl
+        - -w
+        - net.ipv4.ip_forward=1
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        name: init-sysctl
+        securityContext:
+          privileged: true
+          runAsNonRoot: false
+          runAsUser: 0
+    {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/deploy/helm/wg-access-server/templates/deployment.yaml
+++ b/deploy/helm/wg-access-server/templates/deployment.yaml
@@ -48,7 +48,6 @@ spec:
               {{- else }}
               name: {{ $fullName }}
               {{- end }}
-          env: {}
           volumeMounts:
             - name: tun
               mountPath: /dev/net/tun

--- a/deploy/helm/wg-access-server/templates/secret.yaml
+++ b/deploy/helm/wg-access-server/templates/secret.yaml
@@ -1,5 +1,6 @@
 {{- $fullName := include "wg-access-server.fullname" . -}}
 {{- if .Values.wireguard.config.privateKey }}
+{{- if not .Values.existingSecret -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,11 +9,12 @@ metadata:
     {{- include "wg-access-server.labels" . | nindent 4 }}
 type: Opaque
 data:
-  privateKey: {{ .Values.wireguard.config.privateKey | b64enc | quote }}
+  WG_WIREGUARD_PRIVATE_KEY: {{ .Values.wireguard.config.privateKey | b64enc | quote }}
   {{- if .Values.web.config.adminUsername }}
-  adminUsername: {{ .Values.web.config.adminUsername | b64enc | quote }}
+  WG_ADMIN_USERNAME: {{ .Values.web.config.adminUsername | b64enc | quote }}
   {{- end }}
   {{- if .Values.web.config.adminPassword }}
-  adminPassword: {{ .Values.web.config.adminPassword | b64enc | quote }}
+  WG_ADMIN_PASSWORD: {{ .Values.web.config.adminPassword | b64enc | quote }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/wg-access-server/templates/service.yaml
+++ b/deploy/helm/wg-access-server/templates/service.yaml
@@ -51,5 +51,8 @@ spec:
       targetPort: 51820
       protocol: UDP
       name: wireguard
+      {{- if and ( eq .Values.wireguard.service.type "NodePort" ) .Values.wireguard.service.nodePort }}
+      nodePort: {{ .Values.wireguard.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "wg-access-server.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/wg-access-server/values.yaml
+++ b/deploy/helm/wg-access-server/values.yaml
@@ -67,6 +67,7 @@ imagePullSecrets: []
 
 image:
   repository: place1/wg-access-server
+  tag: v0.4.6
   pullPolicy: IfNotPresent
 
 # multiple replicas is only supported when using

--- a/deploy/helm/wg-access-server/values.yaml
+++ b/deploy/helm/wg-access-server/values.yaml
@@ -1,6 +1,20 @@
 # wg-access-server config
 config: {}
 
+## Provide an existing secret with the following keys:
+##
+## data:
+##   WG_ADMIN_PASSWORD: X
+##   WG_ADMIN_USERNAME: X
+##   WG_WIREGUARD_PRIVATE_KEY: X
+##
+## overrides:
+## web.config.adminUsername
+## web.config.adminPassword
+## wireguard.config.privateKey
+##
+# existingSecret: ""
+
 web:
   config:
     adminUsername: ""

--- a/deploy/helm/wg-access-server/values.yaml
+++ b/deploy/helm/wg-access-server/values.yaml
@@ -79,3 +79,12 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+# sysctlInitContainer flag adds an initContainer named "init-sysctl" to wg-access-server deployment.
+# The goal is to set the sysctl net.ipv4.ip_forward=1 to allow packet routing through node.
+# This initContainer needs to run as privileged, but this is only limited to
+# the initContainer run time, the main container will remain unprivileged as expected.
+# Use case : 
+#   DNS is functionning properly through VPN but does not work for standard traffic. 
+# NB : If you have no problem with wireguard traffic, you should not enable this initContainer
+sysctlInitContainer: false

--- a/deploy/helm/wg-access-server/values.yaml
+++ b/deploy/helm/wg-access-server/values.yaml
@@ -27,6 +27,8 @@ wireguard:
     privateKey: ""
   service:
     type: ClusterIP
+    # type: NodePort
+    # nodePort: 51820
 
 persistence:
   enabled: false


### PR DESCRIPTION
1) admin username, password and privatekey can be read from an external secret, to allow the use of for the [sealed-secrets controller](https://github.com/bitnami-labs/sealed-secrets) or [external-secrets](https://github.com/external-secrets/external-secrets).

2) option to specify a specific node port in case service.type = "NodePort" is used. Useful on bare metal deployments where no loadbalancer is available.

Signed-off-by: Florian Buchmeier <flo_buchmeier@web.de>