### PR TITLE
[Readme-docker-deployment] Add missing `\` for docker deployment

### DIFF
--- a/docs/deployment/1-docker.md
+++ b/docs/deployment/1-docker.md
@@ -5,7 +5,7 @@
 Here's a one-liner to run wg-access-server:
 
 ```bash
-docker run --rm -it
+docker run --rm -it \
   --cap-add NET_ADMIN \
   --device /dev/net/tun:/dev/net/tun \
   -p 8000:8000/tcp \


### PR DESCRIPTION
Add missing `\` for docker deployment