### PR TITLE
networking.k8s.io/v1beta1 Ingress is deprecated

### DIFF
--- a/deploy/helm/wg-access-server/templates/ingress.yaml
+++ b/deploy/helm/wg-access-server/templates/ingress.yaml
@@ -28,7 +28,11 @@ spec:
         paths:
           - path: /
             backend:
-              serviceName: {{ $fullName }}-web
-              servicePort: 80
+              service:
+                name:  {{ $fullName }}-web
+                port:
+                  number: 80
+            path: /
+            pathType: Prefix
   {{- end }}
 {{- end }}

--- a/deploy/helm/wg-access-server/templates/ingress.yaml
+++ b/deploy/helm/wg-access-server/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "wg-access-server.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/deploy/helm/wg-access-server/templates/ingress.yaml
+++ b/deploy/helm/wg-access-server/templates/ingress.yaml
@@ -27,12 +27,11 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
               service:
                 name:  {{ $fullName }}-web
                 port:
                   number: 80
-            path: /
-            pathType: Prefix
   {{- end }}
 {{- end }}


### PR DESCRIPTION
W0608 13:29:30.543511   79209 warnings.go:70] 
networking.k8s.io/v1beta1 Ingress is deprecated in v1.19+, unavailable in v1.22+; use networking.k8s.io/v1 Ingress