### PR TITLE
fix(helm): update ingress apiVersion

### DIFF
--- a/deploy/helm/wg-access-server/templates/ingress.yaml
+++ b/deploy/helm/wg-access-server/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "wg-access-server.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}

--- a/deploy/helm/wg-access-server/templates/ingress.yaml
+++ b/deploy/helm/wg-access-server/templates/ingress.yaml
@@ -27,8 +27,11 @@ spec:
       http:
         paths:
           - path: /
+            pathType: ImplementationSpecific
             backend:
-              serviceName: {{ $fullName }}-web
-              servicePort: 80
+              service:
+                name: {{ $fullName }}-web
+                port:
+                  number: 80
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This is a fix for the fact that the `networking.k8s.io/v1beta1` API version of Ingress was deprecated is no longer served as of v1.22, see: https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122