### PR TITLE
Update ingress.yaml

### DIFF
--- a/deploy/helm/wg-access-server/templates/ingress.yaml
+++ b/deploy/helm/wg-access-server/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "wg-access-server.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
The extensions/v1beta1 and networking.k8s.io/v1beta1 API versions of Ingress is no longer served as of v1.22.

