### PR TITLE
readme fix: update deploy with helm quick link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Quick Links:
 
 - [Configuration Overview](https://place1.github.io/wg-access-server/2-configuration/)
 - [Deploy With Docker](https://place1.github.io/wg-access-server/deployment/1-docker/)
-- [Deploy With Helm](https://place1.github.io/wg-access-server/deployment/2-docker-compose/)
 - [Deploy With Docker-Compose](https://place1.github.io/wg-access-server/deployment/2-docker-compose/)
+- [Deploy With Helm](https://place1.github.io/wg-access-server/deployment/3-kubernetes/)
 
 ## Running with Docker
 


### PR DESCRIPTION
Updates README.md to fix "deploy with Helm" quick link (was pointed at docker-compose), and move to bottom of list to match doc site.